### PR TITLE
Fix for - Knowledge tool throws error for perplexity key not available.

### DIFF
--- a/python/helpers/perplexity_search.py
+++ b/python/helpers/perplexity_search.py
@@ -10,6 +10,7 @@ import os
 
 
 api_key_from_env = os.getenv("API_KEY_PERPLEXITY")
+DEFAULT_RESPONSE = " Can not search internet, as there is no OpenAI key configured."
 
 class PerplexityCrewLLM(BaseLLM):
     api_key: str
@@ -63,7 +64,8 @@ class PerplexityCrewLLM(BaseLLM):
     
 
 def PerplexitySearchLLM(api_key,model_name="sonar-medium-online",base_url="https://api.perplexity.ai"):    
-    client = OpenAI(api_key=api_key_from_env, base_url=base_url)
+    client = OpenAI(api_key=api_key_from_env, base_url=base_url) if api_key_from_env else None
+
         
     def call_model(query:str):
         messages = [
@@ -84,11 +86,13 @@ def PerplexitySearchLLM(api_key,model_name="sonar-medium-online",base_url="https
         },
         ]
         
-        response = client.chat.completions.create(
-            model=model_name,
-            messages=messages, # type: ignore
-        )
-        result = response.choices[0].message.content #only the text is returned
+        result = DEFAULT_RESPONSE
+        if client:
+            response = client.chat.completions.create(
+                model=model_name,
+                messages=messages, # type: ignore
+            )
+            result = response.choices[0].message.content #only the text is returned
         return result
     
     return call_model


### PR DESCRIPTION
When we run the agent without openAI key (In my case I used Groq for LLMs) and that needs knowledge_tools, it throws the error as shown in below screenshot. That happens as the `perplexity_search.py` file loads on initialization and if the Perplexity key is not configured / not found, it fails to creates the client.

Before change:
<img width="1676" alt="Screenshot 2024-08-03 at 5 35 26 PM" src="https://github.com/user-attachments/assets/137fe4ea-4237-41c3-858c-917ad76d3103">


After change:
<img width="1720" alt="Screenshot 2024-08-03 at 5 43 13 PM" src="https://github.com/user-attachments/assets/834dcde5-4e00-43bc-985a-1ef206e94889">
