### PR TITLE
add tips for running on NixOS

### DIFF
--- a/docs/nixos.md
+++ b/docs/nixos.md
@@ -1,0 +1,14 @@
+# Running Agent-Zero on NixOS
+
+The command `nix develop` will give you a shell with python and system
+dependencies installed. (This uses the provided `flake.nix` in the project
+root)
+
+Then install the python dependencies using pip in a virtual-environment:
+
+```
+python3 -m venv virtual-environment-dir
+source virtual-environment-dir/bin/activate
+pip install -r requirements.txt
+```
+

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  inputs = {
+    utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, nixpkgs, utils }: utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in
+    {
+      packages.default = pkgs.hello;
+      devShells.default = pkgs.mkShell {
+        buildInputs = with pkgs; [
+        (python3.withPackages (pkgs: with pkgs; [ pip ]))
+        gcc
+        ];
+        LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib";
+      };
+    }
+  );
+}


### PR DESCRIPTION
This PR adds instructions and the files necessary to conveniently run agent-zero on a NixOS system.

Rather than package up agent-zero as a nix-expression I've opted to instead make it easy to produce an environment that enables hacking on it, since that seems like it's a main use case.