### PR TITLE
Fixed azure embedding deployment name parameter

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ def initialize():
     # embedding model used for memory
     embedding_llm = models.get_openai_embedding(model_name="text-embedding-3-small")
     # embedding_llm = models.get_ollama_embedding(model_name="nomic-embed-text")
+    # embedding_llm = models.get_azure_openai_embedding(deployment="text-embedding-3-large")
     # embedding_llm = models.get_huggingface_embedding(model_name="sentence-transformers/all-MiniLM-L6-v2")
 
     # agent configuration

--- a/models.py
+++ b/models.py
@@ -68,10 +68,10 @@ def get_azure_openai_instruct(deployment_name:str, api_key=None, temperature=DEF
     azure_endpoint = azure_endpoint or os.getenv("OPENAI_AZURE_ENDPOINT")
     return AzureOpenAI(deployment_name=deployment_name, temperature=temperature, api_key=api_key, azure_endpoint=azure_endpoint) # type: ignore
 
-def get_azure_openai_embedding(deployment_name:str, api_key=None, azure_endpoint=None):
+def get_azure_openai_embedding(deployment:str, api_key=None, azure_endpoint=None):
     api_key = api_key or get_api_key("openai_azure")
     azure_endpoint = azure_endpoint or os.getenv("OPENAI_AZURE_ENDPOINT")
-    return AzureOpenAIEmbeddings(deployment_name=deployment_name, api_key=api_key, azure_endpoint=azure_endpoint) # type: ignore
+    return AzureOpenAIEmbeddings(deployment=deployment, api_key=api_key, azure_endpoint=azure_endpoint) # type: ignore
 
 # Google models
 def get_google_chat(model_name:str, api_key=None, temperature=DEFAULT_TEMPERATURE):


### PR DESCRIPTION
AzureOpenAIEmbeddings expects deployment to be without "_name" suffix. Also added missing example to main.py how to select it to be used.