### PR TITLE
Setup docker-compose strategy

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -35,7 +35,7 @@ class AgentConfig:
     max_tool_response_length: int = 3000
     code_exec_docker_enabled: bool = True
     code_exec_docker_name: str = "agent-zero-exe"
-    code_exec_docker_image: str = "frdel/agent-zero-exe:latest"
+    code_exec_docker_image: str = "agent-zero-exe"
     code_exec_docker_ports: dict[str,int] = field(default_factory=lambda: {"22/tcp": 50022})
     code_exec_docker_volumes: dict[str, dict[str, str]] = field(default_factory=lambda: {files.get_abs_path("work_dir"): {"bind": "/root", "mode": "rw"}})
     code_exec_ssh_enabled: bool = True

--- a/docker/.bashrc
+++ b/docker/.bashrc
@@ -7,3 +7,6 @@ fi
 
 # Activate the virtual environment
 source /opt/venv/bin/activate
+
+# Change to the desired work directory upon SSH login
+cd /home/agent-zero/work_dir

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,24 @@ FROM --platform=$TARGETPLATFORM debian:bookworm-slim
 # Set ARG for platform-specific commands
 ARG TARGETPLATFORM
 
+ENV DEBIAN_FRONTEND noninteractive
+ENV TERM linux
+
+# Define locales.
+ENV LANGUAGE en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+ENV LC_CTYPE en_US.UTF-8
+ENV LC_MESSAGES en_US.UTF-8
+
+USER root
+
+ARG user_name
+# Adding user
+RUN useradd -rm -d /home/$user_name -s /bin/bash -g root -G sudo -u 1001 $user_name \
+ && echo "${user_name}:${user_name}" | chpasswd
+
+
 # Update and install necessary packages
 RUN apt-get update && apt-get install -y \
     python3 \
@@ -13,7 +31,13 @@ RUN apt-get update && apt-get install -y \
     npm \
     openssh-server \
     sudo \
+    locales \
     && rm -rf /var/lib/apt/lists/*
+
+# Generate the locale
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen en_US.UTF-8 && \
+    update-locale LANG=en_US.UTF-8
 
 # Set up SSH
 RUN mkdir /var/run/sshd && \
@@ -27,9 +51,22 @@ RUN python3 -m venv $VIRTUAL_ENV
 # Copy initial .bashrc with virtual environment activation to a temporary location
 COPY .bashrc /etc/skel/.bashrc
 
+WORKDIR /home/$user_name
+
+# Python Dependencies
+COPY ./requirements.txt requirements.txt 
+
+# Update the PATH environment variable so that the correct pip and python are used
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN pip install --upgrade pip \
+ && pip install --upgrade setuptools \
+ && pip install -r requirements.txt
+
 # Copy the script to ensure .bashrc is in the root directory
-COPY initialize.sh /usr/local/bin/initialize.sh
-RUN chmod +x /usr/local/bin/initialize.sh
+COPY initialize.sh /home/$user_name/initialize.sh
+RUN chmod +x /home/$user_name/initialize.sh
+RUN sed -i -e 's/\r$//' /home/$user_name/initialize.sh
 
 # Ensure the virtual environment and pip setup
 RUN $VIRTUAL_ENV/bin/pip install --upgrade pip
@@ -41,3 +78,4 @@ EXPOSE 22
 CMD ["/usr/local/bin/initialize.sh"]
 
 
+WORKDIR /home/$user_name/work_dir

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.9"
+
+#name: &PROJECTNAME agent-zero
+
+services:
+  agent-zero-exe:
+    container_name: agent-zero-exe
+    build:
+      context: ./
+      dockerfile: ./Dockerfile
+      args:
+          user_name: agent-zero 
+    ports:
+      - "50022:22"
+
+    volumes:
+      - ./../work_dir:/home/agent-zero/work_dir
+
+    entrypoint: ["/bin/bash", "-c", "/home/agent-zero/initialize.sh"]
+    command: ["tail", "-f", "/dev/null"]

--- a/docker/initialize.sh
+++ b/docker/initialize.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x  # This will print each command before executing it
 
 # Ensure .bashrc is in the root directory
 if [ ! -f /root/.bashrc ]; then
@@ -11,6 +12,13 @@ if [ ! -f /root/.profile ]; then
     cp /etc/skel/.bashrc /root/.profile
     chmod 444 /root/.profile
 fi
+
+# Add the command to change directory upon login
+if ! grep -Fxq "cd /home/agent-zero/work_dir" /root/.bashrc; then
+    echo "cd /home/agent-zero/work_dir" >> /root/.bashrc
+fi
+
+echo "cd /home/agent-zero/work_dir" >> /home/agent-zero/.bashrc
 
 apt-get update
 

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,0 +1,3 @@
+requests
+pylint
+pdfkit

--- a/initialize.py
+++ b/initialize.py
@@ -48,8 +48,8 @@ def initialize():
         code_exec_ssh_enabled = True,
         # code_exec_ssh_addr = "localhost",
         # code_exec_ssh_port = 50022,
-        # code_exec_ssh_user = "root",
-        # code_exec_ssh_pass = "toor",
+        code_exec_ssh_user = "agent-zero",
+        code_exec_ssh_pass = "agent-zero",
         # additional = {},
     )
     

--- a/python/helpers/docker.py
+++ b/python/helpers/docker.py
@@ -1,3 +1,6 @@
+from typing import Optional
+import subprocess
+import docker
 import time
 import docker
 import atexit
@@ -6,6 +9,7 @@ from python.helpers.files import get_abs_path
 from python.helpers.errors import format_error
 from python.helpers.print_style import PrintStyle
 from python.helpers.log import Log
+import os
 
 class DockerContainerManager:
     def __init__(self, image: str, name: str, ports: Optional[dict[str, int]] = None, volumes: Optional[dict[str, dict[str, str]]] = None):
@@ -14,7 +18,7 @@ class DockerContainerManager:
         self.ports = ports
         self.volumes = volumes
         self.init_docker()
-                
+
     def init_docker(self):
         self.client = None
         while not self.client:
@@ -24,25 +28,18 @@ class DockerContainerManager:
             except Exception as e:
                 err = format_error(e)
                 if ("ConnectionRefusedError(61," in err or "Error while fetching server API version" in err):
-                    PrintStyle.hint("Connection to Docker failed. Is docker or Docker Desktop running?") # hint for user
+                    PrintStyle.hint("Connection to Docker failed. Is docker or Docker Desktop running?")
                     Log.log(type="hint", content="Connection to Docker failed. Is docker or Docker Desktop running?")
                     PrintStyle.error(err)
                     Log.log(type="error", content=err)
                     time.sleep(5) # try again in 5 seconds
                 else: raise
         return self.client
-                            
+
     def cleanup_container(self) -> None:
-        if self.container:
-            try:
-                self.container.stop()
-                self.container.remove()
-                print(f"Stopped and removed the container: {self.container.id}")
-                Log.log(type="info", content=f"Stopped and removed the container: {self.container.id}")
-            except Exception as e:
-                print(f"Failed to stop and remove the container: {e}")
-                Log.log(type="error", content=f"Failed to stop and remove the container: {e}")
-                
+        subprocess.run(["docker-compose", "-f", os.path.join("..", "docker", "docker-compose.yml"), "down"])
+        print(f"Stopped and removed the container: {self.name}")
+        Log.log(type="info", content=f"Stopped and removed the container: {self.name}")
 
     def start_container(self) -> None:
         if not self.client: self.client = self.init_docker()
@@ -53,29 +50,43 @@ class DockerContainerManager:
                 break
 
         if existing_container:
-            if existing_container.status != 'running':
+            if existing_container.status != "running":
                 print(f"Starting existing container: {self.name} for safe code execution...")
                 Log.log(type="info", content=f"Starting existing container: {self.name} for safe code execution...")
-                
                 existing_container.start()
                 self.container = existing_container
                 time.sleep(2) # this helps to get SSH ready
-                
             else:
                 self.container = existing_container
-                # print(f"Container with name '{self.name}' is already running with ID: {existing_container.id}")
         else:
-            print(f"Initializing docker container {self.name} for safe code execution...")
-            Log.log(type="info", content=f"Initializing docker container {self.name} for safe code execution...")
+            # Assuming that self.name is set correctly
+            compose_file_path = os.path.join("..", "docker", "docker-compose.yml")
 
-            self.container = self.client.containers.run(
-                self.image,
-                detach=True,
-                ports=self.ports, # type: ignore
-                name=self.name,
-                volumes=self.volumes, # type: ignore
-            ) 
-            atexit.register(self.cleanup_container)
-            print(f"Started container with ID: {self.container.id}")
-            Log.log(type="info", content=f"Started container with ID: {self.container.id}")
-            time.sleep(5) # this helps to get SSH ready
+            # Check if the file exists before running the command
+            if not os.path.exists(compose_file_path):
+                print(f"Error: docker-compose.yml not found at {compose_file_path}")
+                Log.log(type="error", content=f"docker-compose.yml not found at {compose_file_path}")
+
+            try:
+                print(f"Initializing docker container {self.name} for safe code execution...")
+                Log.log(type="info", content=f"Initializing docker container {self.name} for safe code execution...")
+
+                # Run docker-compose command
+                result = subprocess.run(["docker-compose", "-f", compose_file_path, "up", "-d"], check=True, capture_output=True, text=True)
+
+                # Debug output of the subprocess result
+                print(f"Docker-compose output: {result.stdout}")
+                print(f"Docker-compose error (if any): {result.stderr}")
+
+                self.container = self.client.containers.get(self.name)
+                atexit.register(self.cleanup_container)
+
+                print(f"Started container with ID: {self.container.id}")
+                Log.log(type="info", content=f"Started container with ID: {self.container.id}")
+
+                time.sleep(5)  # this helps to get SSH ready
+            except subprocess.CalledProcessError as e:
+                print(f"Failed to run docker-compose: {e}")
+                print(f"Error output: {e.stderr}")
+                Log.log(type="error", content=f"Failed to run docker-compose: {e.stderr}")
+


### PR DESCRIPTION
I prefer to organize my project using a docker-compose file. Instead of pulling the frdel image from the Docker registry, this setup builds the image locally when needed.

This approach makes it easier to manage mounted volumes, network ports, and hardware resources (such as GPUs). Additionally, I’ve added a requirements.txt file, which can be extended with commonly used user packages for more flexibility.