### PR TITLE
feature: attachments preview and sending (file, code, imgs)

### DIFF
--- a/python/extensions/message_loop_prompts/_30_include_attachments.py
+++ b/python/extensions/message_loop_prompts/_30_include_attachments.py
@@ -1,53 +1,40 @@
+# python/extensions/monologue_start/include_attachments.py
 from python.helpers.extension import Extension
+from python.helpers.attachment_manager import AttachmentManager
 from agent import Agent, LoopData
 import os
-import io
-import base64
-from PIL import Image
 
 class IncludeAttachments(Extension):
-    async def execute(self, loop_data: LoopData = LoopData(), **kwargs):
-        # Check if there are attachments in agent data
-        attachments = self.agent.get_data('attachments') or []
-        if attachments:
-            loop_data.attachments = [] # Initialize attachments list for loop_data
-
-            # For each attachment, compress and encode the image
-            for attachment_path in attachments:
-                if os.path.exists(attachment_path):
-                    # Prepare the base64-encoded image
-                    compressed_image_base64 = self.compress_and_encode_image(attachment_path)
-                    if compressed_image_base64:
-                        # Append the image data to loop_data.attachments
-                        loop_data.attachments.append(f"<image>{compressed_image_base64}</image>")
-
-            # Clear attachments from agent data
-            self.agent.set_data('attachments', [])
-
-    def compress_and_encode_image(self, image_path: str) -> str:
-        try:
-            # Open an image file
-            with Image.open(image_path) as img:
-                # Convert image to RGB if it's in RGBA mode
-                if img.mode in ('RGBA', 'P'):
-                    img = img.convert('RGB')
-                
-                # Resize the image to a reasonable size
-                max_dimension = 800  # You can adjust this value
-                img.thumbnail((max_dimension, max_dimension))
-                
-                # Compress the image
-                buffered = io.BytesIO()
-                # Save as JPEG to ensure compression; you can adjust quality
-                img.save(buffered, format="JPEG", quality=70, optimize=True)
-                compressed_image = buffered.getvalue()
-                
-                # Encode the compressed image in base64
-                return base64.b64encode(compressed_image).decode('utf-8')
-        except Exception as e:
-            print(f"Error compressing and encoding image {image_path}: {e}")
-            return ""
-
-    def estimate_token_count(self, message: str) -> int:
-        # Simple estimation: assume 4 characters per token
-        return len(message) // 4
+  async def execute(self, loop_data: LoopData = LoopData(), **kwargs):
+      attachments = self.agent.get_data('attachments') or []
+      if attachments:
+          loop_data.attachments = []
+          file_manager = AttachmentManager(os.path.join(os.getcwd(), 'work_dir'))
+          
+          for attachment in attachments:
+              if os.path.exists(attachment):
+                  filename = os.path.basename(attachment)
+                  file_type = file_manager.get_file_type(filename)
+                  
+                  attachment_html = f'<div class="attachment-item attachment-{file_type}">'
+                  if file_type == 'image':
+                    preview = file_manager.generate_image_preview(attachment)
+                    if preview:
+                        attachment_html += f'<img src="data:image/jpeg;base64,{preview}" alt="{filename}" class="attachment-preview"/>'
+                  else:
+                    # Add placeholder for non-image files
+                    attachment_html += f'<div class="attachment-placeholder">{file_type.upper()}</div>'
+                  
+                  # Add filename and extension badge
+                  ext = file_manager.get_file_extension(filename)
+                  attachment_html += f'''
+                    <div class="attachment-info">
+                        <span class="attachment-name">{filename}</span>
+                        <span class="attachment-badge">{ext}</span>
+                    </div>
+                  </div>'''
+                  
+                  loop_data.attachments.append(attachment_html)
+          
+          # Clear attachments after processing
+          self.agent.set_data('attachments', [])

--- a/python/helpers/attachment_manager.py
+++ b/python/helpers/attachment_manager.py
@@ -1,0 +1,91 @@
+import os
+import io
+import base64
+from PIL import Image
+from typing import Dict, List, Optional, Tuple
+from werkzeug.utils import secure_filename
+
+class AttachmentManager:
+  ALLOWED_EXTENSIONS = {
+      'image': {'jpg', 'jpeg', 'png', 'bmp'},
+      'code': {'py', 'js', 'sh', 'html', 'css'},
+      'document': {'md', 'pdf', 'txt', 'csv', 'json'}
+  }
+  
+  def __init__(self, work_dir: str):
+      self.work_dir = work_dir
+      os.makedirs(work_dir, exist_ok=True)
+
+  def is_allowed_file(self, filename: str) -> bool:
+      ext = self.get_file_extension(filename)
+      all_allowed = set().union(*self.ALLOWED_EXTENSIONS.values())
+      return ext in all_allowed
+
+  def get_file_type(self, filename: str) -> str:
+      ext = self.get_file_extension(filename)
+      for file_type, extensions in self.ALLOWED_EXTENSIONS.items():
+          if ext in extensions:
+              return file_type
+      return 'unknown'
+
+  @staticmethod
+  def get_file_extension(filename: str) -> str:
+      return filename.rsplit('.', 1)[1].lower() if '.' in filename else ''
+  
+  def validate_mime_type(self, file) -> bool:
+      try:
+          mime_type = file.content_type
+          return mime_type.split('/')[0] in ['image', 'text', 'application']
+      except AttributeError:
+          return False
+
+  def save_file(self, file, filename: str) -> Tuple[str, Dict]:
+      """Save file and return path and metadata"""
+      try:
+          filename = secure_filename(filename)
+          if not filename:
+              raise ValueError("Invalid filename")
+              
+          file_path = os.path.join(self.work_dir, filename)
+          
+          file_type = self.get_file_type(filename)
+          metadata = {
+              'filename': filename,
+              'type': file_type,
+              'extension': self.get_file_extension(filename),
+              'preview': None
+          }
+  
+          # Save file
+          file.save(file_path)
+  
+          # Generate preview for images
+          if file_type == 'image':
+              metadata['preview'] = self.generate_image_preview(file_path)
+  
+          return file_path, metadata
+        
+      except Exception as e:
+          print(f"Error saving file {filename}: {e}")
+          return None, {} # type: ignore
+
+  def generate_image_preview(self, image_path: str, max_size: int = 800) -> Optional[str]:
+      try:
+          with Image.open(image_path) as img:
+              # Convert image if needed
+              if img.mode in ('RGBA', 'P'):
+                  img = img.convert('RGB')
+              
+              # Resize for preview
+              img.thumbnail((max_size, max_size))
+              
+              # Save to buffer
+              buffer = io.BytesIO()
+              img.save(buffer, format="JPEG", quality=70, optimize=True)
+              
+              # Convert to base64
+              return base64.b64encode(buffer.getvalue()).decode('utf-8')
+      except Exception as e:
+          print(f"Error generating preview for {image_path}: {e}")
+          return None
+      

--- a/python/helpers/log.py
+++ b/python/helpers/log.py
@@ -4,165 +4,166 @@ from typing import Any, Literal, Optional, Dict
 import uuid
 from collections import OrderedDict  # Import OrderedDict
 
-
 Type = Literal[
-    "agent",
-    "code_exe",
-    "error",
-    "hint",
-    "info",
-    "progress",
-    "response",
-    "tool",
-    "user",
-    "util",
-    "warning",
+  "agent",
+  "code_exe",
+  "error",
+  "hint",
+  "info",
+  "progress",
+  "response",
+  "tool",
+  "user",
+  "util",
+  "warning",
 ]
-
 
 @dataclass
 class LogItem:
-    log: "Log"
-    no: int
-    type: str
-    heading: str
-    content: str
-    temp: bool
-    kvps: Optional[OrderedDict] = None  # Use OrderedDict for kvps
-    guid: str = ""
+  log: "Log"
+  no: int
+  type: str
+  heading: str
+  content: str
+  temp: bool
+  kvps: Optional[OrderedDict] = None  # Use OrderedDict for kvps
+  id: Optional[str] = None  # Add id field
+  guid: str = ""
 
-    def __post_init__(self):
-        self.guid = self.log.guid
+  def __post_init__(self):
+      self.guid = self.log.guid
 
-    def update(
-        self,
-        type: Type | None = None,
-        heading: str | None = None,
-        content: str | None = None,
-        kvps: dict | None = None,
-        temp: bool | None = None,
-        **kwargs,
-    ):
-        if self.guid == self.log.guid:
-            self.log.update_item(
-                self.no,
-                type=type,
-                heading=heading,
-                content=content,
-                kvps=kvps,
-                temp=temp,
-                **kwargs,
-            )
+  def update(
+      self,
+      type: Type | None = None,
+      heading: str | None = None,
+      content: str | None = None,
+      kvps: dict | None = None,
+      temp: bool | None = None,
+      **kwargs,
+  ):
+      if self.guid == self.log.guid:
+          self.log.update_item(
+              self.no,
+              type=type,
+              heading=heading,
+              content=content,
+              kvps=kvps,
+              temp=temp,
+              **kwargs,
+          )
 
-    def stream(self, heading: str | None = None, content: str | None = None, **kwargs):
-        if heading is not None:
-            self.update(heading=self.heading + heading)
-        if content is not None:
-            self.update(content=self.content + content)
+  def stream(self, heading: str | None = None, content: str | None = None, **kwargs):
+      if heading is not None:
+          self.update(heading=self.heading + heading)
+      if content is not None:
+          self.update(content=self.content + content)
 
-        for k, v in kwargs.items():
-            prev = self.kvps.get(k, "") if self.kvps else ""
-            self.update(**{k: prev + v})
+      for k, v in kwargs.items():
+          prev = self.kvps.get(k, "") if self.kvps else ""
+          self.update(**{k: prev + v})
 
-    def output(self):
-        return {
-            "no": self.no,
-            "type": self.type,
-            "heading": self.heading,
-            "content": self.content,
-            "temp": self.temp,
-            "kvps": self.kvps,
-        }
-
+  def output(self):
+      return {
+          "no": self.no,
+          "id": self.id,  # Include id in output
+          "type": self.type,
+          "heading": self.heading,
+          "content": self.content,
+          "temp": self.temp,
+          "kvps": self.kvps,
+      }
 
 class Log:
 
-    def __init__(self):
-        self.guid: str = str(uuid.uuid4())
-        self.updates: list[int] = []
-        self.logs: list[LogItem] = []
-        self.progress = ""
-        self.progress_no = 0
+  def __init__(self):
+      self.guid: str = str(uuid.uuid4())
+      self.updates: list[int] = []
+      self.logs: list[LogItem] = []
+      self.progress = ""
+      self.progress_no = 0
 
-    def log(
-        self,
-        type: Type,
-        heading: str | None = None,
-        content: str | None = None,
-        kvps: dict | None = None,
-        temp: bool | None = None,
-    ) -> LogItem:
-        # Use OrderedDict if kvps is provided
-        if kvps is not None:
-            kvps = OrderedDict(kvps)
-        item = LogItem(
-            log=self,
-            no=len(self.logs),
-            type=type,
-            heading=heading or "",
-            content=content or "",
-            kvps=kvps,
-            temp=temp or False,
-        )
-        self.logs.append(item)
-        self.updates += [item.no]
-        if heading and item.no >= self.progress_no:
-            self.progress = heading
-            self.progress_no = item.no
-        return item
+  def log(
+      self,
+      type: Type,
+      heading: str | None = None,
+      content: str | None = None,
+      kvps: dict | None = None,
+      temp: bool | None = None,
+      id: Optional[str] = None,  # Add id parameter
+  ) -> LogItem:
+      # Use OrderedDict if kvps is provided
+      if kvps is not None:
+          kvps = OrderedDict(kvps)
+      item = LogItem(
+          log=self,
+          no=len(self.logs),
+          type=type,
+          heading=heading or "",
+          content=content or "",
+          kvps=kvps,
+          temp=temp or False,
+          id=id,  # Pass id to LogItem
+      )
+      self.logs.append(item)
+      self.updates += [item.no]
+      if heading and item.no >= self.progress_no:
+          self.progress = heading
+          self.progress_no = item.no
+      return item
 
-    def update_item(
-        self,
-        no: int,
-        type: str | None = None,
-        heading: str | None = None,
-        content: str | None = None,
-        kvps: dict | None = None,
-        temp: bool | None = None,
-        **kwargs,
-    ):
-        item = self.logs[no]
-        if type is not None:
-            item.type = type
-        if heading is not None:
-            item.heading = heading
-            if no >= self.progress_no:
-                self.progress = heading
-                self.progress_no = no
-        if content is not None:
-            item.content = content
-        if kvps is not None:
-            item.kvps = OrderedDict(kvps)  # Use OrderedDict to keep the order
+  def update_item(
+      self,
+      no: int,
+      type: str | None = None,
+      heading: str | None = None,
+      content: str | None = None,
+      kvps: dict | None = None,
+      temp: bool | None = None,
+      **kwargs,
+  ):
+      item = self.logs[no]
+      if type is not None:
+          item.type = type
+      if heading is not None:
+          item.heading = heading
+          if no >= self.progress_no:
+              self.progress = heading
+              self.progress_no = no
+      if content is not None:
+          item.content = content
+      if kvps is not None:
+          item.kvps = OrderedDict(kvps)  # Use OrderedDict to keep the order
 
-        if temp is not None:
-            item.temp = temp
+      if temp is not None:
+          item.temp = temp
 
-        if kwargs:
-            if item.kvps is None:
-                item.kvps = OrderedDict()  # Ensure kvps is an OrderedDict
-            for k, v in kwargs.items():
-                item.kvps[k] = v
+      if kwargs:
+          if item.kvps is None:
+              item.kvps = OrderedDict()  # Ensure kvps is an OrderedDict
+          for k, v in kwargs.items():
+              item.kvps[k] = v
 
-        self.updates += [item.no]
+      self.updates += [item.no]
 
-    def output(self, start=None, end=None):        
-        if start is None:
-            start = 0
-        if end is None:
-            end = len(self.updates)
+  def output(self, start=None, end=None):        
+      if start is None:
+          start = 0
+      if end is None:
+          end = len(self.updates)
 
-        out = []
-        seen = set()
-        for update in self.updates[start:end]:
-            if update not in seen:
-                out.append(self.logs[update].output())
-                seen.add(update)
+      out = []
+      seen = set()
+      for update in self.updates[start:end]:
+          if update not in seen:
+              out.append(self.logs[update].output())
+              seen.add(update)
 
-        return out
+      return out
 
-    def reset(self):
-        self.guid = str(uuid.uuid4())
-        self.updates = []
-        self.logs = []
-        self.progress = ""
-        self.progress_no = 0
+  def reset(self):
+      self.guid = str(uuid.uuid4())
+      self.updates = []
+      self.logs = []
+      self.progress = ""
+      self.progress_no = 0

--- a/webui/index.css
+++ b/webui/index.css
@@ -516,6 +516,14 @@ pre {
   text-align: end;
 }
 
+.message-user > div {
+padding-top: var(--spacing-xs);
+font-family: 'Roboto Mono', monospace;
+font-optical-sizing: auto;
+-webkit-font-optical-sizing: auto;
+font-size: var(--font-size-small)
+}
+
 .message-ai {
   border-bottom-left-radius: var(--spacing-xs);
 }
@@ -785,7 +793,6 @@ pre {
   align-items: center;
   gap: var(--spacing-xs);
 }
-
 /* Attachment icon */
 .attachment-wrapper {
   position: relative;
@@ -796,7 +803,7 @@ pre {
   cursor: pointer;
   color: var(--color-text);
   opacity: 0.7;
-  transition: opacity 0.2s;
+  transition: opacity 0.2s ease;
   display: flex;
   align-items: center;
 }
@@ -809,24 +816,195 @@ pre {
   opacity: 0.5;
 }
 
+/* Message attachments styles */
 .attachments-container {
-  margin-top: 10px;
-  padding: 10px;
-  border-radius: 5px;
+  margin-top: 0.5em;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
 }
 
-.message-attachment {
-  max-width: 100%;
-  max-height: 400px;
-  margin: 5px 0;
-  border-radius: 5px;
+.attachment-item {
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  background: var(--color-background);
+  padding: 0.5em;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+}
+
+.attachment-item:hover {
+  background: var(--color-secondary-dark);
+}
+
+.attachment-item.file-type {
+  background: var(--color-background);
+}
+
+.attachment-item:hover {
+  background: var(--color-secondary-dark);
+}
+
+.attachment-preview {
+  max-width: 100px;
+  max-height: 100px;
+  border-radius: 4px;
   object-fit: contain;
 }
 
+.attachment-image .attachment-preview {
+  margin-right: 8px;
+}
+
+.attachment-info,
+.file-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.file-info {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+}
+
+.attachment-name,
+.filename,
+.file-name {
+  font-size: 0.9em;
+  color: var(--color-text);
+  word-break: break-word;
+}
+
+.attachment-ext,
+.extension,
+.file-ext {
+  background: var(--color-primary);
+  color: var(--color-text);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.8em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+/* Preview section styles */
+.preview-section {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 10px;
+  padding: var(--spacing-xs);
+}
+
+.preview-item {
+  position: relative;
+  background: var(--color-secondary);
+  border-radius: 8px;
+  padding: 8px;
+  max-width: 200px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transition: background-color 0.2s ease;
+}
+
+.preview-item:hover {
+  background: var(--color-secondary-dark);
+}
+
+.preview-item.image-preview img {
+  max-height: 100px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+.image-wrapper {
+  width: 100px;
+  height: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.file-preview {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+}
+
+.extension {
+  background: var(--color-primary);
+  color: var(--color-text);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.8em;
+  text-transform: uppercase;
+}
+
+.file-preview:hover {
+  background: var(--color-secondary-dark);
+}
+
+.remove-attachment {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  background-color: var(--color-primary);
+  /* opacity: 0.6; */
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease, transform 0.1s ease;
+  z-index: 1;
+}
+
+.remove-attachment:hover {
+  background-color: var(--color-accent);
+  transform: scale(1.1);
+}
+
+.remove-attachment:active {
+  transform: scale(0.9);
+}
+
+/* File type specific styles
+.extension[data-type="image"] {
+  background: #4CAF50;
+}
+
+.extension[data-type="code"] {
+  background: #2196F3;
+}
+
+.extension[data-type="document"] {
+  background: #FF9800;
+}
+
+*/
+
+/* Error handling */
 .image-error {
-  border: 1px solid #ff0000;
+  border: 1px solid var(--color-error);
   padding: 10px;
-  color: #ff0000;
+  color: var(--color-error);
+  border-radius: 4px;
+  font-size: 0.9em;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.image-error::before {
+  content: "⚠️";
 }
 
 /* Text input */

--- a/webui/index.html
+++ b/webui/index.html
@@ -195,34 +195,63 @@
                         alert('Maximum 4 attachments allowed');
                         return;
                     }
-                    
+    
                     Array.from(files).forEach(file => {
-                        if (file.type.startsWith('image/')) {
-                            const reader = new FileReader();
-                            reader.onload = e => {
+                        const ext = file.name.split('.').pop().toLowerCase();
+                        const allowedExts = new Set(['jpg', 'jpeg', 'png', 'bmp', 'md', 'py', 'js', 'sh', 
+                                                    'html', 'css', 'pdf', 'txt', 'csv', 'json']);
+                        
+                        if (allowedExts.has(ext)) {
+                            const isImage = ['jpg', 'jpeg', 'png', 'bmp'].includes(ext);
+                            
+                            if (isImage) {
+                                // Handle image preview
+                                const reader = new FileReader();
+                                reader.onload = e => {
+                                    this.attachments.push({
+                                        file: file,
+                                        url: e.target.result,
+                                        type: 'image',
+                                        name: file.name,
+                                        extension: ext
+                                    });
+                                    this.hasAttachments = true;
+                                };
+                                reader.readAsDataURL(file);
+                            } else {
+                                // Handle other file types
                                 this.attachments.push({
                                     file: file,
-                                    url: e.target.result
+                                    type: 'file',
+                                    name: file.name,
+                                    extension: ext
                                 });
                                 this.hasAttachments = true;
-                            };
-                            reader.readAsDataURL(file);
+                            }
                         }
                     });
                 }
             }">
-
-                <!-- Image preview section -->
-                <div x-show="hasAttachments" class="image-preview-section">
-                    <template x-for="(image, index) in attachments" :key="index">
-                        <div class="preview-item">
-                            <img :src="image.url" alt="Preview">
-                            <button @click="attachments.splice(index, 1); hasAttachments = attachments.length > 0"
-                                class="remove-image">&times;</button>
+    
+                <!-- Preview section -->
+                <div x-show="hasAttachments" class="preview-section">
+                    <template x-for="(attachment, index) in attachments" :key="index">
+                        <div class="preview-item" :class="{'image-preview': attachment.type === 'image'}">
+                            <template x-if="attachment.type === 'image'">
+                                <img :src="attachment.url" :alt="attachment.name">
+                            </template>
+                            <template x-if="attachment.type === 'file'">
+                                <div class="file-preview">
+                                    <span class="filename" x-text="attachment.name"></span>
+                                    <span class="extension" x-text="attachment.extension.toUpperCase()"></span>
+                                </div>
+                            </template>
+                            <button @click="attachments.splice(index, 1); hasAttachments = attachments.length > 0" 
+                                    class="remove-attachment">&times;</button>
                         </div>
                     </template>
                 </div>
-
+    
                 <!-- Top row with input and buttons -->
                 <div class="input-row">
                     <!-- Attachment icon with tooltip -->
@@ -235,20 +264,20 @@
                                     d="M16.5 6v11.5c0 2.21-1.79 4-4 4s-4-1.79-4-4V5c0-1.38 1.12-2.5 2.5-2.5s2.5 1.12 2.5 2.5v10.5c0 .55-.45 1-1 1s-1-.45-1-1V6H10v9.5c0 1.38 1.12 2.5 2.5 2.5s2.5-1.12 2.5-2.5V5c0-2.21-1.79-4-4-4S7 2.79 7 5v12.5c0 3.04 2.46 5.5 5.5 5.5s5.5-2.46 5.5-5.5V6h-1.5z" />
                             </svg>
                         </label>
-                        <input type="file" id="file-input" accept="png, jpg, jpeg, txt, pdf, csv, html, json, md"
-                            multiple style="display: none" @change="handleFileUpload($event)">
+                        <input type="file" id="file-input" accept=".png, .jpg, .jpeg, .txt, .pdf, .csv, .html, .json, .md, .py, .js, .sh, .css" multiple style="display: none"
+                        @change="handleFileUpload($event)">
 
-                        <div x-show="showTooltip" class="tooltip">
-                            Limit: 4 attachments per message
-                        </div>
+                    <div x-show="showTooltip" class="tooltip">
+                        Limit: 4 attachments per message
                     </div>
+                </div>
 
-                    <!-- Text input -->
-                    <textarea id="chat-input" placeholder="Type your message here..." rows="1"></textarea>
+                <!-- Text input -->
+                <textarea id="chat-input" placeholder="Type your message here..." rows="1"></textarea>
 
-                    <div id="chat-buttons-wrapper">
-                        <!-- Send button -->
-                        <button class="chat-button" id="send-button" aria-label="Send message">
+                <div id="chat-buttons-wrapper">
+                    <!-- Send button -->
+                    <button class="chat-button" id="send-button" aria-label="Send message">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
                                 <path d="M25 20 L75 50 L25 80" fill="none" stroke="currentColor" stroke-width="15">
                                 </path>


### PR DESCRIPTION
Support for previewing and sending attachments like images, text files, and code in the chat.

- Utilized OrderedDict for maintaining the order of key-value pairs in logs
- Integrated unique message_id handling to prevent duplicate message rendering
- Enhanced front-end logic to manage and display attachments

Supported File Formats:
Images: JPEG, PNG
Text: TXT, CSV, PDF
Code: PY, JS, HTML, CSS, MD, JSON

![Screenshot from 2024-11-12 15-06-48](https://github.com/user-attachments/assets/19e5d4e9-312c-47dc-9702-d655ebbe1271)
