### PR TITLE
(WIP) fix: do not crash the call if tool returns empty response

### DIFF
--- a/python/helpers/tool.py
+++ b/python/helpers/tool.py
@@ -8,7 +8,7 @@ from python.helpers import messages
 class Response:
     message:str
     break_loop:bool
-    
+
 class Tool:
 
     def __init__(self, agent: Agent, name: str, args: dict[str,str], message: str, **kwargs) -> None:
@@ -29,13 +29,19 @@ class Tool:
                 PrintStyle(font_color="#85C1E9", bold=True).stream(self.nice_key(key)+": ")
                 PrintStyle(font_color="#85C1E9", padding=isinstance(value,str) and "\n" in value).stream(value)
                 PrintStyle().print()
-                
+
     async def after_execution(self, response: Response, **kwargs):
-        text = response.message.strip()
+        # Check if response or message is None
+        if not response or response.message is None:
+            text = ""
+            PrintStyle(font_color="red").print(f"Warning: Tool '{self.name}' returned None response or message")
+        else:
+            text = response.message.strip()
+
         await self.agent.hist_add_tool_result(self.name, text)
         PrintStyle(font_color="#1B4F72", background_color="white", padding=True, bold=True).print(f"{self.agent.agent_name}: Response from tool '{self.name}'")
-        PrintStyle(font_color="#85C1E9").print(response.message)
-        self.log.update(content=response.message)
+        PrintStyle(font_color="#85C1E9").print(text)
+        self.log.update(content=text)
 
     def get_log_object(self):
         return self.agent.context.log.log(type="tool", heading=f"{self.agent.agent_name}: Using tool '{self.name}'", content="", kvps=self.args)


### PR DESCRIPTION
Sometimes a tool can return an empty response (for example if browser_agent uses less capable model).
This triggers the red stacktrace in the chat.

Because the agent zero already checks for invalid responses, lets fix the crash in code.
