### PR TITLE
Playwright firefox deps

### DIFF
--- a/docker/run/fs/ins/pre_install.sh
+++ b/docker/run/fs/ins/pre_install.sh
@@ -11,7 +11,14 @@ apt-get update && apt-get install -y \
     curl \
     wget \
     git \
-    ffmpeg 
+    ffmpeg \
+    libgtk-3-0 \
+    libnss3 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libasound2 \
+    libasound2-data
 
 # Configure system alternatives so that /usr/bin/python3 points to Python 3.12
 sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1


### PR DESCRIPTION
Some mcp servers already use firefox from playwright by default.
Make them happy instead of a crash/error on call