### PR TITLE
(WIP) fix: prevent agent from responding beyond the first valid response JSON object

### DIFF
--- a/python/extensions/message_loop_end/_95_reset_agent_data.py
+++ b/python/extensions/message_loop_end/_95_reset_agent_data.py
@@ -1,0 +1,7 @@
+from python.helpers.extension import Extension
+from agent import LoopData
+
+
+class ResetAgentData(Extension):
+    async def execute(self, loop_data: LoopData = LoopData(), **kwargs):
+        self.agent.set_data('agent_responded', False)


### PR DESCRIPTION
Sometime, the agent keeps generating far beyond a full response json.
It might even happen that the agent indefinitely generates multiple json responses trying to use more than one tool at once.

This PR stops the streaming loop when we detected the first full response object is unchanged since previous chunk.