### PR TITLE
fix: import sentence_transfomers on pure cpu was failing

### DIFF
--- a/docker/base/fs/ins/install_python.sh
+++ b/docker/base/fs/ins/install_python.sh
@@ -46,7 +46,7 @@ source /opt/venv/bin/activate
 # upgrade pip and install static packages
 pip install --upgrade pip ipython requests
 # Install some packages in specific variants
-pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install torch==2.7.0+cpu torchvision==0.22.0+cpu --index-url https://download.pytorch.org/whl/cpu
 
 
 echo "====================PYTHON END===================="

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,8 +29,11 @@ playwright==1.52.0
 pypdf==4.3.1
 python-dotenv==1.1.0
 pytz==2024.2
-sentence-transformers==3.0.1
-tiktoken==0.8.0
+sentence-transformers[cpu]==4.1.0
+tiktoken==0.9.0
+torch[cpu]==2.7.0+cpu
+torchvision[cpu]==0.22.0+cpu
+transformers[cpu]==4.52.4
 unstructured==0.15.13
 unstructured-client==0.25.9
 webcolors==24.6.0


### PR DESCRIPTION
On pure intel cpu machine the import of sentence_transformers was failing with:
Error: Error in preload_embedding: Could not import sentence_transformers python package. Please install it with `pip install sentence-transformers`.

Tis Pr fixes it for me.
