### PR TITLE
Fixed issue 433

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -684,8 +684,8 @@ class Agent:
             await self.handle_intervention()  # wait if paused and handle intervention message if needed
             await tool.after_execution(response)
             await self.handle_intervention()  # wait if paused and handle intervention message if needed
-            if response.break_loop:
-                return response.message
+            if response and getattr(response, "break_loop", False):
+                return getattr(response, "message", "")
         else:
             msg = self.read_prompt("fw.msg_misformat.md")
             self.hist_add_warning(msg)

--- a/python/helpers/tool.py
+++ b/python/helpers/tool.py
@@ -33,11 +33,12 @@ class Tool:
                 PrintStyle().print()
 
     async def after_execution(self, response: Response, **kwargs):
-        text = response.message.strip()
+        message = getattr(response, "message", "")
+        text = message.strip() if isinstance(message, str) else ""
         self.agent.hist_add_tool_result(self.name, text)
         PrintStyle(font_color="#1B4F72", background_color="white", padding=True, bold=True).print(f"{self.agent.agent_name}: Response from tool '{self.name}'")
-        PrintStyle(font_color="#85C1E9").print(response.message)
-        self.log.update(content=response.message)
+        PrintStyle(font_color="#85C1E9").print(message)
+        self.log.update(content=message)
 
     def get_log_object(self):
         if self.method:


### PR DESCRIPTION
Resolved issue #433 by adding a null check to safely handle cases where response.message is None. This prevents the AttributeError: 'NoneType' object has no attribute 'strip' by verifying that message is a string before applying .strip(). The update ensures robust post-execution logging and display without breaking the tool pipeline.