### PR TITLE
Implement tunnel provider selection

### DIFF
--- a/python/api/tunnel.py
+++ b/python/api/tunnel.py
@@ -14,7 +14,8 @@ class Tunnel(ApiHandler):
         
         if action == "create":
             port = runtime.get_web_ui_port()
-            tunnel_url = tunnel_manager.start_tunnel(port)
+            provider = input.get("provider", "serveo")  # Default to serveo
+            tunnel_url = tunnel_manager.start_tunnel(port, provider)
             if tunnel_url is None:
                 # Add a little delay and check again - tunnel might be starting
                 import time

--- a/python/helpers/tunnel_manager.py
+++ b/python/helpers/tunnel_manager.py
@@ -18,30 +18,26 @@ class TunnelManager:
         self.tunnel = None
         self.tunnel_url = None
         self.is_running = False
+        self.provider = None
 
-    def start_tunnel(self, port=80):
+    def start_tunnel(self, port=80, provider="serveo"):
         """Start a new tunnel or return the existing one's URL"""
         if self.is_running and self.tunnel_url:
             return self.tunnel_url
 
-
-        # switched to serveo to support SSE MCP server
-
-        # Create and start a new tunnel
-        # config = FlareConfig(
-        #     port=port,
-        #     verbose=True,
-        #     timeout=60,  # Increase timeout from default 30 to 60 seconds
-        # )
-
-        config = ServeoConfig(port=port) # type: ignore
+        self.provider = provider
 
         try:
             # Start tunnel in a separate thread to avoid blocking
             def run_tunnel():
                 try:
-                    # self.tunnel = FlareTunnel(config)
-                    self.tunnel = ServeoTunnel(config)
+                    if self.provider == "cloudflared":
+                        config = FlareConfig(port=port, verbose=True)
+                        self.tunnel = FlareTunnel(config)
+                    else:  # Default to serveo
+                        config = ServeoConfig(port=port)
+                        self.tunnel = ServeoTunnel(config)
+
                     self.tunnel.start()
                     self.tunnel_url = self.tunnel.tunnel_url
                     self.is_running = True
@@ -72,6 +68,7 @@ class TunnelManager:
                 self.tunnel.stop()
                 self.is_running = False
                 self.tunnel_url = None
+                self.provider = None
                 return True
             except Exception:
                 return False

--- a/webui/index.html
+++ b/webui/index.html
@@ -715,6 +715,19 @@
                             <div id="section-tunnel" class="section" x-show="activeTab === 'external'">
                                 <div class="section-title">Flare Tunnel</div>
                                 <div class="section-description">Create a secure public URL to access your Agent Zero instance anytime, anywhere.</div>
+                                <div class="field">
+                                    <div class="field-label">
+                                        <div class="field-title">Tunnel provider</div>
+                                        <div class="field-description">Select provider for public tunnel</div>
+                                    </div>
+                                    <div class="field-control">
+                                        <select id="tunnel-provider" x-model="provider" :disabled="isLoading">
+                                            <option value="serveo">Serveo</option>
+                                            <option value="cloudflared">Cloudflare</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <!-- Tunnel content UI -->
                                 <div class="tunnel-container" x-data="tunnelSettings">
                                     <!-- Loading spinner for tunnel operations -->
                                     <div class="loading-spinner" x-show="isLoading">
@@ -749,7 +762,6 @@
                                                 </button>
                                             </div>
                                         </div>
-                                        
                                         <!-- Generate tunnel button when no link exists -->
                                         <div class="tunnel-actions" x-show="!linkGenerated">
                                             <button class="btn btn-ok" @click="generateLink()">

--- a/webui/js/settings.js
+++ b/webui/js/settings.js
@@ -4,6 +4,7 @@ const settingsModalProxy = {
     settings: {},
     resolvePromise: null,
     activeTab: 'agent', // Default tab
+    provider: 'serveo',
 
     // Computed property for filtered sections
     get filteredSections() {

--- a/webui/js/tunnel.js
+++ b/webui/js/tunnel.js
@@ -159,6 +159,11 @@ document.addEventListener('alpine:init', () => {
             
             this.isLoading = true;
             this.loadingText = 'Creating tunnel...';
+
+            // Get provider from the parent settings modal scope
+            const modalEl = document.getElementById('settingsModal');
+            const modalAD = Alpine.$data(modalEl);
+            const provider = modalAD.provider || 'serveo'; // Default to serveo if not set
             
             // Change create button appearance
             const createButton = document.querySelector('.tunnel-actions .btn-ok');
@@ -177,6 +182,7 @@ document.addEventListener('alpine:init', () => {
                     },
                     body: JSON.stringify({ 
                         action: 'create',
+                        provider: provider
                         // port: window.location.port || (window.location.protocol === 'https:' ? 443 : 80)
                     }),
                 });


### PR DESCRIPTION
- Adds a UI dropdown to select between Cloudflare and Serveo tunnel providers.
- Implements backend logic to create the selected tunnel.
- Enhances flexibility for exposing the local instance publicly.