### PR TITLE
add open message links in a new window

### DIFF
--- a/webui/js/messages.js
+++ b/webui/js/messages.js
@@ -155,7 +155,7 @@ export function _drawMessage(
   return messageDiv;
 }
 
-function addBlankTargetsToLinks(str) {
+export function addBlankTargetsToLinks(str) {
   const doc = new DOMParser().parseFromString(str, 'text/html');
 
   doc.querySelectorAll('a').forEach(anchor => {

--- a/webui/js/messages.js
+++ b/webui/js/messages.js
@@ -111,6 +111,7 @@ export function _drawMessage(
       processedContent = convertImgFilePaths(processedContent);
       processedContent = marked.parse(processedContent, { breaks: true });
       processedContent = convertPathsToLinks(processedContent);
+      processedContent = addBlankTargetsToLinks(processedContent);
       spanElement.innerHTML = processedContent;
 
       // KaTeX rendering for markdown
@@ -152,6 +153,22 @@ export function _drawMessage(
   }
 
   return messageDiv;
+}
+
+function addBlankTargetsToLinks(str) {
+  const doc = new DOMParser().parseFromString(str, 'text/html');
+
+  doc.querySelectorAll('a').forEach(anchor => {
+    if (!anchor.hasAttribute('target') || anchor.getAttribute('target') === '') {
+      anchor.setAttribute('target', '_blank');
+    }
+
+    const rel = (anchor.getAttribute('rel') || '').split(/\s+/).filter(Boolean);
+    if (!rel.includes('noopener')) rel.push('noopener');
+    if (!rel.includes('noreferrer')) rel.push('noreferrer');
+    anchor.setAttribute('rel', rel.join(' '));
+  });
+  return doc.body.innerHTML;
 }
 
 export function drawMessageDefault(


### PR DESCRIPTION
Added `addBlankTargetsToLinks(str)` to webui/js/messages.js, which adds `target='_blank'` attribute to message links during rendering, while maintaining security practices such as setting `noopener` and `noreferrer` relation