### PR TITLE
Fix displaying images

### DIFF
--- a/python/api/image_get.py
+++ b/python/api/image_get.py
@@ -6,6 +6,14 @@ from flask import Request, Response, send_file
 
 
 class ImageGet(ApiHandler):
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["GET"]
+
+    @classmethod
+    def requires_auth(cls) -> bool:
+        return False
+
     async def process(self, input: dict, request: Request) -> dict | Response:
             # input data
             path = input.get("path", request.args.get("path", ""))


### PR DESCRIPTION
Image displaying for browser-use was not working. As it turned out, images were not working at all. The reason is the api endpoint for getting images, which was expecting the HTTP POST method. Also, without disabling auth it returned 403.
After this change, images started working, as well as displaying browser-use.

![Screenshot 2025-06-30 at 17 14 16](https://github.com/user-attachments/assets/1c773ae4-6dc7-4fc0-9afd-dcba54f5c41d)
![Screenshot 2025-06-30 at 17 17 20](https://github.com/user-attachments/assets/38165e76-43c9-4ef6-ad4b-42db66585a0c)
